### PR TITLE
Pages style : box shadows

### DIFF
--- a/css/page.css
+++ b/css/page.css
@@ -23,6 +23,7 @@ article.page h3 {
 article.page p > img {
   display: block;
   margin: auto;
+  box-shadow: 0 0 20px -5px;
 }
 
 .warning, .protip {


### PR DESCRIPTION
L'idée c'est d'ajouter deux  `box-shadow` (j'ai croisé avec Florie pour vérifier que je n'en abusais pas trop quand-même).

Le premier permet de délimiter le contenu de la page, pour faciliter sa lecture.
Le second permet de faire ressortir le contour des images qui ont un fond blanc.

Et les petits screenshots habituels, pour voir le avant / après :
![screenshot121](https://cloud.githubusercontent.com/assets/803869/5414742/be37e324-8221-11e4-9b1c-b85c6e7906cb.png)
![screenshot120](https://cloud.githubusercontent.com/assets/803869/5414743/be3ce086-8221-11e4-9f4d-48a17df213d5.png)
