### PR TITLE
Add: border to elements with box-shadow

### DIFF
--- a/css/page.css
+++ b/css/page.css
@@ -1,5 +1,6 @@
 .container.marketing {
   box-shadow: 0 0 55px -25px;
+  border: 1px solid #E8E8E8;
 }
 
 article.page p {
@@ -24,6 +25,7 @@ article.page p > img {
   display: block;
   margin: auto;
   box-shadow: 0 0 20px -5px;
+  border: 1px solid #E8E8E8;
 }
 
 .warning, .protip {


### PR DESCRIPTION
Comme [suggéré ici](https://github.com/TEA-ebook/help-center/pull/4#issuecomment-66799762), j'ajoute une petite bordure aux éléments qui ont un `box-shadow` comme fallback pour les navigateurs qui ne savent pas faire.

Par contre je trouve ça un poil moins joli quand il y a bien l'ombrage, ça me fait un peu de peine. Il n'y a pas de moyen « simple » de le mettre seulement si `box-shadow` n'est pas supporté ?
