### PR TITLE
Add: navbar box-shadow

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -11,6 +11,10 @@ body {
 /* CUSTOMIZE THE NAVBAR
 -------------------------------------------------- */
 
+nav.navbar {
+  box-shadow: 0 0 10px 3px;
+}
+
 /* Special class on .container surrounding .navbar, used for positioning it into place. */
 .navbar-wrapper {
   position: absolute;


### PR DESCRIPTION
Julien a fait remarquer que ça faisait bizarre que le contenu semble surélevé du fait de son ombre alors qu'il passe _sous_ la navbar qui n'en n'a pas.
Du coup certains trouveront ça moins choquant avec une ombre sur la navbar aussi (ou alors il faudra supprimer celle du contenu et trouver un autre moyen de « délimiter » le contenu).
