### PR TITLE
Add: prerequisite to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 TEA Help Center
 ===============
 
-## Tester le site en local.
+## Pré-Requis
 
-Installer Jekyll :
-```
-bundle install
-```
+* Ruby
+* NodeJS
+
+## Tester en local
 
 Lancer Jekyll :
 ```
 bundle exec jekyll serve
 ```
+
+Puis accéder à [http://localhost:4000/]
 
 ## Liens problématiques présents dans ces pages d'aides :
 


### PR DESCRIPTION
Parce ce que ça n'était pas évident pour moi quand j'ai installé le projet.

(Et l'URL en local c'est parce que Jekyll propose 0.0.0.0:4000 mais je préfère localhost)
