### PR TITLE
POC google custom search

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -5,6 +5,21 @@ layout: default
 <div class="row">
   <div class="col-md-12" role="main">
     <article class="page col-lg-9">
+      <div class="googlesearch">
+        <script>
+  (function() {
+    var cx = '009432820896978244847:a4aaumzki1y';
+    var gcse = document.createElement('script');
+    gcse.type = 'text/javascript';
+    gcse.async = true;
+    gcse.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') +
+        '//cse.google.com/cse.js?cx=' + cx;
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(gcse, s);
+  })();
+        </script>
+        <gcse:search></gcse:search>
+      </div>
       <header>
         <h1>{{ page.title }}</h1>
       </header>

--- a/_sass/global.scss
+++ b/_sass/global.scss
@@ -103,3 +103,16 @@ p#anchor-menu-title{
     border-bottom: 7px solid transparent;
   }
 }
+
+.googlesearch { // google search adjustments
+  * {
+    box-sizing: content-box;
+  }
+  table {
+    border-collapse: separate;
+  }
+  td, th {
+    padding: 0;
+    vertical-align: middle;
+  }
+}


### PR DESCRIPTION
J'ai assez salement ajouté un champ de recherche en haut de toutes les pages (hors FAQ et accueil dans un premier temps) : 

![screenshot 2015-07-23 a 11 40 04](https://cloud.githubusercontent.com/assets/1035145/8847648/2c4fa43c-3131-11e5-9cc3-6de7cea1f9b5.png)

Et quand on cherche ça donne ceci : 

![screenshot 2015-07-23 a 11 40 59](https://cloud.githubusercontent.com/assets/1035145/8847656/40ba6cfe-3131-11e5-95cf-c4a29f34b207.png)

J'avoue ne pas être complètement convaincue : la longueur des pages et la structure du site rend les résultats de google un peu inutiles, notamment si on atterrit dans la FAQ (quand on clique sur le lien "FAQ" dans les résultats, on atterrit en haut de page… donc un peu bof…)

Ping @fsechaud et @cGuille 
