### PR TITLE
Fix: double click on search result bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /_site/
 .sass-cache/
+.idea

--- a/js/faq-search.js
+++ b/js/faq-search.js
@@ -6,7 +6,7 @@ $(function onLoad() {
     var initialText = $results.find('.no-results').text();
 
     function displayResultText(text) {
-        $results.empty().append($('<p>').text(text).addClass('no-results'));
+        $results.html($('<p>').text(text).addClass('no-results'));
     }
 
     function constructResults() {
@@ -58,7 +58,7 @@ $(function onLoad() {
             results.append(result);
         }
 
-        $results.empty().append(results);
+        $results.html(results);
     }
 
     function searchAndDisplay() {
@@ -82,7 +82,7 @@ $(function onLoad() {
         event.preventDefault();
     });
 
-    $('#text-search').bind('keyup change', searchAndDisplay);
+    $('#text-search').bind('keyup', searchAndDisplay);
     searchAndDisplay.call($('#text-search'));
 
     $results.on('click', '.see-more', function() {


### PR DESCRIPTION
Sur la super recherche de la FAQ, il y avait un bug sur les liens des résultats de recherche : il fallait cliquer 2 fois pour que le lien fonctionne.

Le coupable : un `change` handler sur l'`input` de recherche. Au premier click sur un lien de résultat, le `change` est déclenché et tous les résultats sont re générés et le `MouseEvent` click disparaît aussi.

Voilà le `change` ne sert à rien, il dégage.

ping @tut-tuuut, @astranchet  et @fsechaud  (faut bien 3 personnes pour un si gros commit)
