### PR TITLE
Bouton de feedback

### DIFF
--- a/_includes/feedback-button.html
+++ b/_includes/feedback-button.html
@@ -1,4 +1,4 @@
-<div class="feedback center">Cette réponse vous a-t-elle aidée ? 
+<div class="feedback">Cette réponse vous a-t-elle aidée ? 
 	<form action="https://formspree.io/astranchet@tea-ebook.com" method="POST">
 	    <input type="hidden" name="page" value="{{ page.url }}">
 	    <input type="hidden" name="question" value="{{ include.question }}">

--- a/_includes/feedback-button.html
+++ b/_includes/feedback-button.html
@@ -1,0 +1,20 @@
+<div class="feedback center">Cette réponse vous a-t-elle aidée ? 
+	<form action="https://formspree.io/astranchet@tea-ebook.com" method="POST">
+	    <input type="hidden" name="page" value="{{ page.url }}">
+	    <input type="hidden" name="question" value="{{ include.question }}">
+	    <input type="hidden" name="feedback" value="👍">
+	    <input type="hidden" name="_next" value="{{ page.url }}" />
+	    <input type="hidden" name="_language" value="fr" />
+	    <input type="hidden" name="_subject" value="[Aide] Feedback" />
+	    <input type="submit" value="Oui 👍">
+	</form>
+	<form action="https://formspree.io/astranchet@tea-ebook.com" method="POST">
+	    <input type="hidden" name="page" value="{{ page.url }}">
+	    <input type="hidden" name="question" value="{{ include.question }}">
+	    <input type="hidden" name="feedback" value="👎">
+	    <input type="hidden" name="_next" value="{{ page.url }}" />
+	    <input type="hidden" name="_language" value="fr" />
+	    <input type="hidden" name="_subject" value="[Aide] Feedback" />
+	    <input type="submit" value="Non 👎">
+	</form>
+</div>

--- a/_includes/feedback-button.html
+++ b/_includes/feedback-button.html
@@ -1,5 +1,5 @@
 <div class="feedback">Cette réponse vous a-t-elle aidée ? 
-	<form action="https://formspree.io/astranchet@tea-ebook.com" method="POST">
+	<form action="https://formspree.io/feedback-aide@tea-ebook.com" method="POST">
 	    <input type="hidden" name="page" value="{{ page.url }}">
 	    <input type="hidden" name="question" value="{{ include.question }}">
 	    <input type="hidden" name="feedback" value="👍">
@@ -8,7 +8,7 @@
 	    <input type="hidden" name="_subject" value="[Aide] Feedback" />
 	    <input type="submit" value="Oui 👍">
 	</form>
-	<form action="https://formspree.io/astranchet@tea-ebook.com" method="POST">
+	<form action="https://formspree.io/feedback-aide@tea-ebook.com" method="POST">
 	    <input type="hidden" name="page" value="{{ page.url }}">
 	    <input type="hidden" name="question" value="{{ include.question }}">
 	    <input type="hidden" name="feedback" value="👎">

--- a/_pages/FAQ-erreur.md
+++ b/_pages/FAQ-erreur.md
@@ -19,6 +19,8 @@ Il faut donc vérifier avec que le livre n'a pas été précédemment ouvert ave
 
 [Vérifier avec quel identifiant Adobe le support a été autorisé.](/faq-comptes/#identifiant-adobe)
 
+{% include feedback-button.html question="E_LIC_ALREADY_FULFILLED_BY_ANOTHER_USER" %}
+
 {% include anchor.html id="request-expired" label="E_ADEPT_REQUEST_EXPIRED" %}
 
 ### E\_ADEPT\_REQUEST\_EXPIRED
@@ -41,6 +43,8 @@ Pour modifier les paramètres Date/heure :
     * Appuyer ensuite sur « Synchroniser l'heure ».
     * Activer aussi la « Synchronisation automatique de l'heure », en appuyant sur le bouton On/Off
 
+{% include feedback-button.html question="E_ADEPT_REQUEST_EXPIRED" %}
+
 {% include anchor.html id="livre-abime-protege" label="Impossible de lire ce livre il est peut-être abîmé ou protégé (sur liseuse)" %}
 
 ### Impossible de lire ce livre il est peut-être abîmé ou protégé (sur liseuse)
@@ -55,6 +59,8 @@ Il faut donc vérifier avec que le livre n'a pas été précédemment ouvert ave
 
 [Vérifier avec quel identifiant Adobe le support a été autorisé.](/faq-comptes/#identifiant-adobe)
 
+{% include feedback-button.html question="Impossible de lire ce livre il est peut-être abîmé ou protégé (sur liseuse)" %}
+
 {% include anchor.html id="protege-adobe-DRM" label="Ce livre est protégé par Adobe DRM. Pour le lire vous devez activer votre compte Adobe sur votre appareil..." %}
 
 ### Ce livre est protégé par Adobe DRM. Pour le lire vous devez activer votre compte Adobe sur votre appareil...
@@ -68,7 +74,9 @@ Il s'agit d'un message d'avertissement qui apparaît lors du premier télécharg
     * Connecter le wifi
     * Renseigner le compte Adobe
     * Activer l'appareil
-    
+
+{% include feedback-button.html question="Ce livre est protégé par Adobe DRM. Pour le lire vous devez activer votre compte Adobe sur votre appareil..." %}
+
 {% include anchor.html id="ADE-Windows10" label="Adobe Digital Editions sur Windows 10" %}
 
 ### Adobe Digital Editions sur Windows 10
@@ -77,6 +85,8 @@ Vous avez un ordinateur sur Windows 10 et vous rencontrez des difficultés à t�
 C'est probablement à cause d'une incompatibilité entre Windows 10 et les dernières mises à jour du logiciel Adobe Digital Editions.
 Nous vous conseillons de désinstaller Adobe Digital Editions et de réinstaller une ancienne version du logiciel.
 [Télécharger une ancienne version de Adobe Digital Editions.](http://www.adobe.com/support/digitaleditions/downloads.html)
+
+{% include feedback-button.html question="Adobe Digital Editions sur Windows 10" %}
 
 {% include anchor.html id="not-ready" label="E_AUTH_NOT_READY ou E_ACT_NOT_READY" %}
 
@@ -96,6 +106,8 @@ Il faut donc retirer manuellement l'autorisation de l'ordinateur.
     4. Localiser aussi HKEY_CURRENT_USER>Software>Adobe>Adept et supprimer le dossier complet.
 
 <div class="warningtip"><p>Si vous possédez une liseuse TEA ou une liseuse Pocketbook Touchlux 2 ou Sense avec le logiciel mis à jour, nous vous conseillons de télécharger vos ebooks directement depuis votre liseuse.</p></div>   
+
+{% include feedback-button.html question="E_AUTH_NOT_READY" %}
 
 {% include anchor.html id="error-check-activation" label="Error check activation" %}
 
@@ -151,6 +163,8 @@ Les versions 4.0.0 et 4.0.1 d'Adobe Digital Editions génèrent régulièrement 
 
 <div class="warningtip"><p>Si vous possédez une liseuse TEA, nous vous conseillons de télécharger vos ebooks directement depuis votre liseuse, depuis l'espace Mes Achats.</p></div>
 
+{% include feedback-button.html question="Error check activation" %}
+
 
 {% include anchor.html id="duplicate-transaction" label="E_ADEPT_DUPLICATE_TRANSACTION_ID" %}
 
@@ -159,7 +173,7 @@ Les versions 4.0.0 et 4.0.1 d'Adobe Digital Editions génèrent régulièrement 
 Lorsque vous rencontrez ce message, cela signifie que votre autorisation Adobe ID n'est plus reconnue par le logiciel Adobe Digital Editions.
 Contactez votre Service Clients et demandez une réinitialisation du lien de votre livre numérique.
 
-{% include feedback-button.html question="400 Bad request" %}
+{% include feedback-button.html question="E_ADEPT_DUPLICATE_TRANSACTION_ID" %}
 
 {% include anchor.html id="400-bad-request" label="Erreur : « 400 Bad Request » à l'ouverture de la librairie ou de mes Achats sur liseuse" %}
 
@@ -175,4 +189,4 @@ Pour corriger cette erreur, il faut supprimer les cookies dans le navigateur de 
  * Ré-essayer alors de vous connecter à votre librairie.
 
 
-{% include feedback-button.html question="400 Bad request" %}
+ {% include feedback-button.html question="400 Bad request" %}

--- a/_pages/FAQ-erreur.md
+++ b/_pages/FAQ-erreur.md
@@ -159,6 +159,8 @@ Les versions 4.0.0 et 4.0.1 d'Adobe Digital Editions génèrent régulièrement 
 Lorsque vous rencontrez ce message, cela signifie que votre autorisation Adobe ID n'est plus reconnue par le logiciel Adobe Digital Editions.
 Contactez votre Service Clients et demandez une réinitialisation du lien de votre livre numérique.
 
+{% include feedback-button.html question="400 Bad request" %}
+
 {% include anchor.html id="400-bad-request" label="Erreur : « 400 Bad Request » à l'ouverture de la librairie ou de mes Achats sur liseuse" %}
 
 ### Erreur : « 400 Bad Request » à l'ouverture de la Librairie ou de Mes Achats sur liseuse
@@ -171,3 +173,6 @@ Pour corriger cette erreur, il faut supprimer les cookies dans le navigateur de 
  * Appuyer ensuite sur « Paramètres », puis sur « Effacer les cookies »
  * Fermer le navigateur pour revenir à la page d'accueil de votre liseuse.
  * Ré-essayer alors de vous connecter à votre librairie.
+
+
+{% include feedback-button.html question="400 Bad request" %}

--- a/_pages/FAQ-telechargement.md
+++ b/_pages/FAQ-telechargement.md
@@ -32,6 +32,8 @@ type: faq
 
 [Comment connaître la version de votre application ou du logiciel de votre liseuse Pocketbook ?](/faq-autre/#version-logiciel)
 
+{% include feedback-button.html question="Après avoir acheté un e-book où puis-je le récupérer ?" %}
+
 {% include anchor.html id="pas-telecharger-ebook" label="Je n’arrive pas à télécharger mon e-book sur mon ordinateur ?" %}
 
 ### Je n’arrive pas à télécharger mon e-book sur mon ordinateur ?
@@ -50,6 +52,8 @@ Le bouton « Télécharger » est :
 - absent : la commande a été annulée et le livre n'est pas téléchargeable ;
 - présent : contacter le service client.
 
+{% include feedback-button.html question="Je n’arrive pas à télécharger mon e-book sur mon ordinateur ?" %}
+
 {% include anchor.html id="pas-telecharger-ebook-liseuse" label="Je n’arrive pas à télécharger mon e-book sur ma liseuse ?" %}
 
 ### Je n’arrive pas à télécharger mon e-book sur ma liseuse ?
@@ -59,3 +63,5 @@ Le bouton « Télécharger » est :
 * Vérifiez que votre liseuse est bien à jour et effectuez une mise à jour si besoin : [Comment mettre à jour ma liseuse Pocketbook / TEA ?](/maj/)
 * Assurez-vous que votre compte client est bien enregistré dans la liseuse :
 [Comment vérifier quel compte client est enregistré sur ma liseuse ?](/faq-comptes/#compte-liseuse)
+
+{% include feedback-button.html question="Je n’arrive pas à télécharger mon e-book sur ma liseuse ?" %}

--- a/_pages/maj.md
+++ b/_pages/maj.md
@@ -27,6 +27,8 @@ La page d'accueil de la liseuse permet de voir quel logiciel est installé.
 
 L'information précise se trouve dans Paramètres > À propos de l'appareil > Logiciel > Version du logiciel ou Paramètres > Logiciel > Version du logiciel.
 
+{% include feedback-button.html question="Quelle est la version du logiciel installé sur ma liseuse ?" %}
+
 {% include anchor.html id="maj5" label="Mise à jour depuis la version 5" %}
 
 ## Mise à jour depuis la version 5

--- a/_sass/style.scss
+++ b/_sass/style.scss
@@ -101,6 +101,9 @@ h4 {
     color: $protipColor;
   }
 }
+.center {
+  text-align: center;
+}
 
 // Top menu
 header {
@@ -417,5 +420,21 @@ footer {
       background-color: $inputBackground;
       font-size: 1em;
     }
+  }
+}
+
+// Feedback
+.feedback {
+  font-style: italic;
+  color: grey;
+  font-size: .75em;
+  margin: 1em 0 3em;
+
+  form, input[type="submit"] {
+    border: none;
+    display: inline;
+  }
+  input[type="submit"]:hover {
+    background: #edece8;
   }
 }


### PR DESCRIPTION
En prévision de la refonte de nos pages d'aide, on aimerait avoir quelques retours sur les contenus existant. Contrainte : on est sur du github pages, on veut tester le concept avant d'investir du temps/de l'argent.

Voici donc une solution du pauvre, pas idéale mais gratuite. Si on a assez de feedback pour avoir envie d'investir plus, on pourra améliorer la chose. Pour le moment donc, je propose deux boutons en dessous de chaque question : "j'ai aimé/j'ai pas aimé". L'info est envoyée par mail via un service gratuit (https://formspree.io/). (Merci @johanpoirier pour l'idée.)

Visuellement donc, ça ressemble à ça 👍 
![capture d ecran 2018-01-09 a 16 49 58](https://user-images.githubusercontent.com/1374389/34729643-90ddd688-f55d-11e7-968e-0dc6c715b606.png)

Comme on est sur un plan gratuit, l'utilisateur doit remplir un captcha 👎 
![capture d ecran 2018-01-09 a 16 50 10](https://user-images.githubusercontent.com/1374389/34729660-9d821624-f55d-11e7-982c-7c641f06b664.png)

L'utilisateur revient ensuite sur la page d'où il vient (mais pas au même niveau 👎 )

Côté administrateur, on reçoit un email qui ressemble à ça : 
![capture d ecran 2018-01-09 a 16 50 36](https://user-images.githubusercontent.com/1374389/34729721-c4176aa0-f55d-11e7-8916-74fd2fc24cae.png)



Voilà donc un premier jet, avec du feedback seulement sur une page (celle des erreurs Adobe). Si ça t'inspire @LMargot on peut ajouter rapidement le même bout de code sur d'autres pages, ainsi que ton email pour que tu sois alertée aussi.
Ensuite, la next step dépendra desi on se fait spammer ou pas :D 

Je pingue aussi @oservieres et @jlevesy pro des solutions pragmatiques.
  