### PR TITLE
Aide ouverte aux commentaires

### DIFF
--- a/_includes/feedback-button.html
+++ b/_includes/feedback-button.html
@@ -16,8 +16,8 @@
 	    <input type="hidden" name="_next" value="{{ page.url }}" />
 	    <input type="hidden" name="_language" value="fr" />
 	    <input type="hidden" name="_subject" value="[Aide] Feedback" />
-	    <span class="thumb-button">Non 👎</span>
-	    <div>
+	    <span class="thumb-button show-comment-form">Non 👎</span>
+	    <div class="comment-form hidden">
 	    	<label>Des suggestions ou commentaires ? <textarea name="comment"></textarea></label>
 	    	<label>Votre email (si vous souhaitez une réponse) <input type="text" name="email" value="" /></label>
 		    <input type="submit" class="button" value="Envoyer">

--- a/_includes/feedback-button.html
+++ b/_includes/feedback-button.html
@@ -1,4 +1,5 @@
-<div class="feedback">Cette réponse vous a-t-elle aidée ? 
+<div class="feedback">
+	<span>Cette réponse vous a-t-elle aidée ?</span>
 	<form action="https://formspree.io/feedback-aide@tea-ebook.com" method="POST">
 	    <input type="hidden" name="page" value="{{ page.url }}">
 	    <input type="hidden" name="question" value="{{ include.question }}">
@@ -6,7 +7,7 @@
 	    <input type="hidden" name="_next" value="{{ page.url }}" />
 	    <input type="hidden" name="_language" value="fr" />
 	    <input type="hidden" name="_subject" value="[Aide] Feedback" />
-	    <input type="submit" value="Oui 👍">
+	    <input type="submit" value="Oui 👍" class="thumb-button">
 	</form>
 	<form action="https://formspree.io/feedback-aide@tea-ebook.com" method="POST">
 	    <input type="hidden" name="page" value="{{ page.url }}">
@@ -15,6 +16,11 @@
 	    <input type="hidden" name="_next" value="{{ page.url }}" />
 	    <input type="hidden" name="_language" value="fr" />
 	    <input type="hidden" name="_subject" value="[Aide] Feedback" />
-	    <input type="submit" value="Non 👎">
+	    <span class="thumb-button">Non 👎</span>
+	    <div>
+	    	<label>Des suggestions ou commentaires ? <textarea name="comment"></textarea></label>
+	    	<label>Votre email (si vous souhaitez une réponse) <input type="text" name="email" value="" /></label>
+		    <input type="submit" class="button" value="Envoyer">
+		</div>
 	</form>
 </div>

--- a/_includes/feedback-button.html
+++ b/_includes/feedback-button.html
@@ -1,5 +1,5 @@
 <div class="feedback">
-	<span>Cette réponse vous a-t-elle aidée ?</span>
+	<span>Cette réponse vous a-t-elle aidé ?</span>
 	<form action="https://formspree.io/feedback-aide@tea-ebook.com" method="POST">
 	    <input type="hidden" name="page" value="{{ page.url }}">
 	    <input type="hidden" name="question" value="{{ include.question }}">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -36,6 +36,7 @@
     <script src="/js/main.js"></script>
     <script src="/js/anchor-menu.js"></script>
     <script src="/js/sav.js"></script>
+    <script src="/js/feedback.js"></script>
     {% if page.type == 'faq' %}
     <script src="/js/faq-search.js"></script>
     {% endif %}

--- a/_sass/style.scss
+++ b/_sass/style.scss
@@ -40,6 +40,9 @@ h4 {
 }
 
 // class utile
+.hidden {
+  display: none;
+}
 .tip {
   padding: 0.8em 0.4em 0.8em 0em;
   margin: 1em 0;

--- a/_sass/style.scss
+++ b/_sass/style.scss
@@ -438,16 +438,56 @@ footer {
 
 // Feedback
 .feedback {
-  font-style: italic;
-  color: grey;
-  font-size: .75em;
-  margin: 1em 0 3em;
 
-  form, input[type="submit"] {
-    border: none;
+  form {
     display: inline;
   }
-  input[type="submit"]:hover {
-    background: #edece8;
+
+  span, label {
+    font-style: italic;
+    color: grey;
+    font-size: .75em;
+  }
+
+  label {
+    display: block;
+    margin: 1em 0;
+  }
+
+  .thumb-button {
+    display: inline;
+    border: none;
+    color: black;
+    font-size: .7em;
+    font-style: normal;
+
+    &:hover {
+      background: #edece8;
+      border-radius: .3em;
+      cursor: default;
+    }
+  }
+  span.thumb-button {
+    padding: .3em;
+  }
+
+  textarea, input[type="text"] {
+    display: block;
+    width: 45%;
+    margin-top: .3em;
+    border: 1px solid #edece8;
+  }
+
+  textarea { height: 5em; }
+  input { height: 2.5em; }
+
+  input[type="submit"].button {
+    font-size: .7em;
+    color: white;
+    margin: 0;
+    padding: .5em 1em;
+    &:hover {
+      background: $buttonBackground; // TODO
+    }
   }
 }

--- a/js/feedback.js
+++ b/js/feedback.js
@@ -1,0 +1,3 @@
+$(".show-comment-form").click(function () {
+	$(this).next(".comment-form").show();
+});


### PR DESCRIPTION
Dans un épisode précédent (#130), on rajoutait un bouton pour obtenir du feedback sur l'aide. 

La bonne nouvelle, c'est qu'en une semaine, ces boutons ont été utilisés plusieurs fois. La mauvaise, c'est que c'était plutôt pour des retours 👎 . Cela nous a permis de corriger quelques pages mais parfois nous manquons de contexte. 

Dans cette PR, je rajoute donc un champ commentaire ainsi qu'un champ email pour éventuellement prendre contact avec la personne : 

![form](https://user-images.githubusercontent.com/1374389/35051582-dea2459a-fba5-11e7-900c-ac32e9e63621.gif)

Côté admin, on reçoit un email : 

![capture d ecran 2018-01-17 a 16 49 32](https://user-images.githubusercontent.com/1374389/35051840-70f3d42c-fba6-11e7-8c39-27cffe2db74f.png)

