### PR TITLE
Fix anchor links

### DIFF
--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -53,6 +53,14 @@ $headerHeight:80px;
   }
 }
 
+// Offset anchors because the header is fixed
+:target {
+  display: block;
+  position: relative;
+  top: -80px; 
+  visibility: hidden;
+}
+
 // Pages
 #content {
   margin: $headerHeight auto;


### PR DESCRIPTION
Les titres des ancres étaient cachées par le menu du haut qui est en position fixe.