### PR TITLE
Display h4 in search results

### DIFF
--- a/js/faq-search.js
+++ b/js/faq-search.js
@@ -14,7 +14,6 @@ $(function onLoad() {
         var anchors = [];
         $('span.highlight').each(function (i, element) {
             var $matchingElement = $(element).closest('.entry > p, .entry > ul, .entry > table, .entry > ol, .entry > h4, .entry > h3');
-            console.log($matchingElement);
             var tagname = $matchingElement.prop('tagName');
             var $title, content;
             if (tagname === 'H3' || tagname === 'H4') {

--- a/js/faq-search.js
+++ b/js/faq-search.js
@@ -13,15 +13,16 @@ $(function onLoad() {
         var resultContent = [];
         var anchors = [];
         $('span.highlight').each(function (i, element) {
-            var $matchingElement = $(element).closest('.entry > p, .entry > ul, .entry > table, .entry > ol, .entry > h3');
+            var $matchingElement = $(element).closest('.entry > p, .entry > ul, .entry > table, .entry > ol, .entry > h4, .entry > h3');
+            console.log($matchingElement);
             var tagname = $matchingElement.prop('tagName');
             var $title, content;
-            if (tagname === 'H3') {
+            if (tagname === 'H3' || tagname === 'H4') {
                 $title = $matchingElement;
                 content = $title.next().text();
             } else {
                 // find title just before matched element
-                var title = $matchingElement.prevAll('h3[id]')[0];
+                var title = $matchingElement.prevAll('h4[id],h3[id]')[0];
                 if (!title) {
                     return;
                 }


### PR DESCRIPTION
Jusque là, on n'affichait que les titres de niveaux h3 dans la recherche.
![capture d ecran 2018-10-10 a 18 07 56](https://user-images.githubusercontent.com/1374389/46750111-88bd7800-ccb7-11e8-9bfe-c80eb4a1b910.png)

Maintenant, on essaye d'abord d'afficher le niveau h4 s'il existe.
![capture d ecran 2018-10-10 a 18 07 32](https://user-images.githubusercontent.com/1374389/46750115-8bb86880-ccb7-11e8-8575-d9d3d9e82ad2.png)
