### PR TITLE
changer de compte client 

### DIFF
--- a/_pages/FAQ-comptes.md
+++ b/_pages/FAQ-comptes.md
@@ -65,7 +65,7 @@ Actuellement, votre liseuse ne peut se connecter qu'à un seul compte à la fois
 Pour changer de compte client sur une liseuse TEA :
 - Aller dans « Paramètres / Comptes et synchronisation / Mon compte client ».
 - Si vous voyez apparaître une icône de cadenas ouvert ainsi que la mention « Connexion » vous pouvez vous enregistrer en saisissant l' adresse mail de votre compte.
-- Si en revanche, vous voyez déjà una adresse mail ainsi que la mention « Se déconnecter » cela signifie qu'un compte client est déjà connecté. Dans ce cas, il faudra le déconnecter car actuellement, votre liseuse peut être connectée à un seul compte à la fois.
+- Si en revanche, vous voyez déjà una adresse mail, cliquez sur « Se déconnecter » pour pouvoir vous connecter à un nouveau compte. Votre liseuse peut être connectée à un seul compte à la fois.
 
 {% include feedback-button.html question="Comment changer de compte client sur une liseuse TEA ?" %}
 

--- a/_pages/FAQ-comptes.md
+++ b/_pages/FAQ-comptes.md
@@ -64,8 +64,8 @@ Actuellement, votre liseuse ne peut se connecter qu'à un seul compte à la fois
 
 Pour changer de compte client sur une liseuse TEA :
 - Aller dans « Paramètres / Comptes et synchronisation / Mon compte client ».
-- Si vous voyez apparaître une icône de cadenas ouvert ainsi que la mention « Connexion » vous pouvez vous enregistrer en saisissant l' adresse mail de votre compte.
-- Si en revanche, vous voyez déjà una adresse mail, cliquez sur « Se déconnecter » pour pouvoir vous connecter à un nouveau compte. Votre liseuse peut être connectée à un seul compte à la fois.
+- Si vous voyez une icône de cadenas ouvert ainsi que la mention « Connexion » vous pouvez vous enregistrer en saisissant l' adresse mail de votre compte.
+- Si un compte est déjà connecté, cliquez sur « Se déconnecter » pour pouvoir vous connecter à un nouveau compte. Votre liseuse peut être connectée à un seul compte à la fois.
 
 {% include feedback-button.html question="Comment changer de compte client sur une liseuse TEA ?" %}
 

--- a/_pages/FAQ-comptes.md
+++ b/_pages/FAQ-comptes.md
@@ -58,9 +58,18 @@ Actuellement, votre liseuse ne peut se connecter qu'à un seul compte à la fois
 
 {% include feedback-button.html question="Comment vérifier quel compte client est entré sur ma liseuse ?" %}
 
+{% include anchor.html id=" changer de compte client de ma liseuse" label="Comment changer de compte client de ma liseuse TEA ?" %}
 
+### Comment changer de compte client sur une liseuse TEA ?
 
+Pour changer de compte client sur une liseuse TEA :
+- Aller dans « Paramètres »
+- Puis dans « Comptes et synchronisation »
+- Et enfin dans « Mon compte client »
+- Si vous voyez apparaître une icône de cadenas ouvert ainsi que la mention « Connexion » vous pouvez vous enregistrer en saisissant l' adresse mail de votre compte.
+- Si en revanche, vous voyez déjà una adresse mail ainsi que la mention « Se déconnecter » cela signifie qu'un compte client est déjà connecté. Dans ce cas, il faudra le déconnecter car actuellement, votre liseuse peut être connectée à un seul compte à la fois.
 
+{% include feedback-button.html question="Comment changer de compte client sur une liseuse TEA ?" %}
 
 {% include anchor.html id="compte-adobe" label="Qu'est-ce que mon compte Adobe, ou Adobe ID ?" %}
 

--- a/_pages/FAQ-comptes.md
+++ b/_pages/FAQ-comptes.md
@@ -63,9 +63,7 @@ Actuellement, votre liseuse ne peut se connecter qu'à un seul compte à la fois
 ### Comment changer de compte client sur une liseuse TEA ?
 
 Pour changer de compte client sur une liseuse TEA :
-- Aller dans « Paramètres »
-- Puis dans « Comptes et synchronisation »
-- Et enfin dans « Mon compte client »
+- Aller dans « Paramètres / Comptes et synchronisation / Mon compte client ».
 - Si vous voyez apparaître une icône de cadenas ouvert ainsi que la mention « Connexion » vous pouvez vous enregistrer en saisissant l' adresse mail de votre compte.
 - Si en revanche, vous voyez déjà una adresse mail ainsi que la mention « Se déconnecter » cela signifie qu'un compte client est déjà connecté. Dans ce cas, il faudra le déconnecter car actuellement, votre liseuse peut être connectée à un seul compte à la fois.
 

--- a/_pages/FAQ-comptes.md
+++ b/_pages/FAQ-comptes.md
@@ -58,7 +58,7 @@ Actuellement, votre liseuse ne peut se connecter qu'à un seul compte à la fois
 
 {% include feedback-button.html question="Comment vérifier quel compte client est entré sur ma liseuse ?" %}
 
-{% include anchor.html id=" changer de compte client de ma liseuse" label="Comment changer de compte client de ma liseuse TEA ?" %}
+{% include anchor.html id="changement-compte-liseuse" label="Comment changer de compte client de ma liseuse TEA ?" %}
 
 ### Comment changer de compte client sur une liseuse TEA ?
 


### PR DESCRIPTION
Suite aux mots saisis "changer de compte",  j'ai crée cette consigne en m'appuyant sur la consigne semblable, à savoir  'Comment vérifier quel compte client est enregistré sur ma liseuse TEA ?'  Cette dernière, reponds en fait déjà à la  question de changement de compte mais  l'intitulé ne l'indique pas.  J'aimerais avoir votre avis, sur le bien-fondé de cette nouvelle consigne. A la limite, on pourrait aussi passer par une éventuelle réformulation de la question existante ( mais qui toutefois,  pourrait la complexifier quelque peu)